### PR TITLE
refactor the "open" method of "Client" class

### DIFF
--- a/rtsp/__init__.py
+++ b/rtsp/__init__.py
@@ -26,7 +26,7 @@ class Client:
             drop_frame_limit: how many dropped frames to endure before dropping a connection
             retry_connection: whether to retry opening the RTSP connection (after a fixed delay of 15s)
         """
-        self.open(rtsp_server_uri,drop_frame_limit,retry_connection,verbose)
+        self._capture = _Stream(rtsp_server_uri,drop_frame_limit,retry_connection,verbose)
 
     def __enter__(self,*args,**kwargs):
         """ Returns the object which later will have __exit__ called.
@@ -37,8 +37,8 @@ class Client:
         """ Together with __enter__, allows support for `with-` clauses. """
         self.close()
 
-    def open(self, rtsp_server_uri = _default_source, drop_frame_limit = _default_drop_frame_limit, retry_connection=_default_retry_connection,verbose = _default_verbose):
-        self._capture = _Stream(rtsp_server_uri,drop_frame_limit,retry_connection,verbose)
+    def open(self):
+        self._capture.open()
 
     def isOpened(self):
         return self._capture.isOpened()


### PR DESCRIPTION
Hi, Mike.
Thanks for your great job of RTSP Client, which helped me a lot in my personal project.

I switched to your client from ffmpeg since it helped me solved the image quality problem. But as I dug deeper, I found something in your code seems inappropriate.

In the "open" method of "Client" class, you instantiated a LiveVideoFeed object, and used it in the "__init__" method to initialize the Client object. I think it is unreasonable to do so. It covered the real function of "open" method. And you passed a default vaule (_default_source) to the rtsp_server_uri parameter. It does no harm to "__init__" method since people will always pass a rtsp uri to instantiate a Client object. But each time when I want to call the "open" method by instance, it's horrible since there has no member variable hold my rtsp uri, and if I ignore this parameter, the method will rewrtie my LiveVideoFeed object with the _default_source (rtsp://192.168.1.168/ufirststream/track1).

So, I made a little change which may be good to this project. I will be glad to receive your response.

Thank you.