### PR TITLE
Enabling of stream restart.

### DIFF
--- a/rtsp/ffmpegstream.py
+++ b/rtsp/ffmpegstream.py
@@ -19,10 +19,6 @@ class Client:
         self._verbose = verbose
 
         self._bg = False
-        self._stream = cv2.VideoCapture(self.rtsp_server_uri)
-        if self._verbose:
-            print("Connected to video source {}.".format(self.rtsp_server_uri))
-
         self.open()
 
     def __enter__(self,*args,**kwargs):
@@ -37,6 +33,9 @@ class Client:
     def open(self):
         if self.isOpened():
             return
+        self._stream = cv2.VideoCapture(self.rtsp_server_uri)
+        if self._verbose:
+            print("Connected to video source {}.".format(self.rtsp_server_uri))
         self._bg = True
         t = Thread(target=self._update, args=())
         t.daemon = True


### PR DESCRIPTION
Moves stream start command to the open call so not only the thread but also the stream starts upon open call.

This is useful in case the stream accidentally stopped.